### PR TITLE
Fix token logging bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const client = new Client({
 
 const TOKEN = process.env.DISCORD_TOKEN;
 
-console.log(DISCORD_TOKEN);
+// Log the token that was loaded from the environment so we know dotenv worked
+console.log(TOKEN);
 // client.once('ready', () => {
 //     console.log(`Logged in as ${client.user.tag}!`);
 // });


### PR DESCRIPTION
## Summary
- print the Discord token variable rather than an undefined variable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870634feb0c832894d74583ca0cf6be