### PR TITLE
Dockerize project, respect PORT in uptime server, and add deployment docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+.env
+.git
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ A Discord bot that automatically monitors League of Legends players and sends no
    node index.js
    ```
 
+## Docker
+
+1. Build the image:
+   ```bash
+   docker build -t league-stalker-bot .
+   ```
+2. Run the container:
+   ```bash
+   docker run --env DISCORD_TOKEN=your-discord-bot-token \
+     --env RIOT_TOKEN=your-riot-api-token \
+     --env PORT=3000 \
+     -p 3000:3000 \
+     league-stalker-bot
+   ```
+3. Verify the health check endpoint:
+   ```bash
+   curl http://localhost:3000/
+   ```
+
+## Deployment (Render + Docker)
+
+1. Create a new **Web Service** on Render and choose **Docker** as the runtime.
+2. Connect the repository and set the service region/plan.
+3. Set environment variables:
+   - `DISCORD_TOKEN`
+   - `RIOT_TOKEN`
+4. Add a health check path of `/` (this maps to the Express endpoint in `functions/upTime.js`).
+5. Add a free uptime ping service (for example, UptimeRobot) to hit `https://<your-service-host>/` every 5–10 minutes.
+
 ## Commands
 
 ### General Commands

--- a/functions/upTime.js
+++ b/functions/upTime.js
@@ -1,10 +1,10 @@
 const express = require('express');
 
-function startKeepAliveServer(port = 3000){
+function startKeepAliveServer(port = Number(process.env.PORT) || 3000) {
     const app = express();
-    
+
     app.get('/', (req, res) => res.send('Bot is alive!'));
-    app.listen(3000, () => console.log('Web server running...'));
+    app.listen(port, () => console.log(`Web server running on ${port}...`));
 }
 
-module.exports = { startKeepAliveServer }
+module.exports = { startKeepAliveServer };


### PR DESCRIPTION
### Motivation

- Make the bot runnable as a container so it can be deployed to Docker-capable hosts (Render, Railway, Fly). 
- Ensure the keep-alive HTTP endpoint can bind to the host-assigned port via the `PORT` environment variable.
- Provide clear Docker build/run instructions and deployment notes including health check and uptime ping guidance.

### Description

- Add a `Dockerfile` that installs production dependencies and runs `node index.js` from `/app`.
- Add a `.dockerignore` to exclude local files like `node_modules`, `.env`, and `README.md` from the image context.
- Update `functions/upTime.js` to use `Number(process.env.PORT) || 3000` and log the actual port the server is listening on.
- Update `README.md` with Docker build/run instructions and Render deployment steps including setting `DISCORD_TOKEN`/`RIOT_TOKEN` and configuring `/` as the health check with an uptime ping service.

### Testing

- No automated tests were run for these changes.
- Basic local verification steps are documented in the `README.md` (build image, run container, `curl /` to verify health).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69644974daa48328ae5d9587b6866def)